### PR TITLE
Refactor scope symbol to be passed to warden

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -56,7 +56,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
     # check for an existing user, authenticated via warden/devise, if enabled
     if DeviseTokenAuth.enable_standard_devise_support
-      devise_warden_user = warden.user(rc.to_s.underscore.to_sym)
+      devise_warden_user = warden.user(rc.model_name.singular.to_sym)
       if devise_warden_user && devise_warden_user.tokens[@client_id].nil?
         @used_auth_by_token = false
         @resource = devise_warden_user


### PR DESCRIPTION
Since we're using engines, the string returned when resource class is underscored will be separated by `/` instead of `_`. This PR will instead use the resource class' `model_name` attribute to get the correct scope we need.

#### Example
Scope is `:access_user`, resource class is `Access::User`

Before: `warden.user` will try to find `:'access/user'`, which returns nil
After: scope expression will now return `:access_user`