### PR TITLE
[Finished #ENG-57] Cleanup old tokens when using SessionsController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ coverage
 .ruby-version
 .ruby-gemset
 tags
+*.swp
+*.swo

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -25,14 +25,11 @@ module DeviseTokenAuth
           render_create_error_bad_credentials
           return
         end
-        # create client id
-        @client_id = SecureRandom.urlsafe_base64(nil, false)
-        @token     = SecureRandom.urlsafe_base64(nil, false)
 
-        @resource.tokens[@client_id] = {
-          token: BCrypt::Password.create(@token),
-          expiry: (Time.now + @resource.token_lifespan).to_i
-        }
+        # Create client credentials
+        @client_id = SecureRandom.urlsafe_base64(nil, false)
+        @token = @resource.create_token(client_id: @client_id)
+
         @resource.save
 
         sign_in(:user, @resource, store: false, bypass: false)


### PR DESCRIPTION
Ref: https://marketboomer.atlassian.net/browse/ENG-57

### Changes
- Create a `#create_token` included method in `User` concern
- Allow cleanup of "old" tokens when creating sessions using `SessionsController`